### PR TITLE
ServiceのGET処理単体テストの実装

### DIFF
--- a/src/main/java/com/raisetech10/liquor_management/entity/Liquor.java
+++ b/src/main/java/com/raisetech10/liquor_management/entity/Liquor.java
@@ -1,5 +1,7 @@
 package com.raisetech10.liquor_management.entity;
 
+import java.util.Objects;
+
 public class Liquor {
     private int id;
     private String liquorType;
@@ -53,5 +55,21 @@ public class Liquor {
 
     public void setAlcoholContent(int alcoholContent) {
         this.alcoholContent = alcoholContent;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+
+        Liquor liquor = (Liquor) obj;
+
+        // ここで各フィールドの比較を行う
+        return id == liquor.id &&
+                Objects.equals(liquorType, liquor.liquorType) &&
+                Objects.equals(producingCountry, liquor.producingCountry) &&
+                Objects.equals(liquorName, liquor.liquorName) &&
+                Objects.equals(alcoholContent, liquor.alcoholContent);
     }
 }

--- a/src/main/java/com/raisetech10/liquor_management/mapper/LiquorMapper.java
+++ b/src/main/java/com/raisetech10/liquor_management/mapper/LiquorMapper.java
@@ -16,7 +16,6 @@ public interface LiquorMapper {
     @Select("Select * FROM liquor")
     List<Liquor> findAll();
 
-    //GET Exception
     @Select("Select * FROM liquor WHERE id = #{id}")
     Optional<Liquor> findById(int id);
 

--- a/src/test/java/com/raisetech10/liquor_management/service/LiquorServiceImplTest.java
+++ b/src/test/java/com/raisetech10/liquor_management/service/LiquorServiceImplTest.java
@@ -1,0 +1,63 @@
+package com.raisetech10.liquor_management.service;
+
+
+import com.raisetech10.liquor_management.Exception.ResourceNotFoundException;
+import com.raisetech10.liquor_management.entity.Liquor;
+import com.raisetech10.liquor_management.mapper.LiquorMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class LiquorServiceImplTest {
+
+    @InjectMocks//注入する（LiquorMapper→ LiquorServiceImpl）
+    LiquorServiceImpl liquorServiceImpl;//テスト対象
+
+    @Mock//スタブの対象↓
+    LiquorMapper liquorMapper;
+
+    //GETテストコード
+    @Test
+    public void findAllメソッドの呼び出しで存在する映画を全部取得すること() {
+        List<Liquor> liquor = List.of(
+                new Liquor(1, "ウイスキー", "スコットランド", "マッカラン", 40),
+                new Liquor(2, "焼酎", "日本", "黒霧島", 25),
+                new Liquor(3, "ブランデー", "フランス", "ヘネシーXO", 40)
+        );
+        doReturn(liquor).when(liquorMapper).findAll();
+        List<Liquor> actual = liquorServiceImpl.findAll();
+        assertThat(actual).isEqualTo(liquor);
+        verify(liquorMapper, times(1)).findAll();
+    }
+
+    @Test
+    public void 存在するリカーのIDを指定した時に正常にリカーが返されること() throws ResourceNotFoundException {
+        doReturn(Optional.of(new Liquor(1, "ウイスキー", "スコットランド", "マッカラン", 40))).when(liquorMapper).findById(1);//スタブ内容
+
+        Liquor actual = liquorServiceImpl.findById(1);
+        assertThat(actual).isEqualTo(new Liquor(1, "ウイスキー", "スコットランド", "マッカラン", 40));
+    }
+
+    @Test
+    public void 存在しないリカーのIDを指定した時に例外処理が動作すること() throws ResourceNotFoundException {
+        doReturn(Optional.empty()).when(liquorMapper).findById(1000);
+        assertThrows(ResourceNotFoundException.class, () -> {
+            liquorServiceImpl.findById(1000);
+        });
+        verify(liquorMapper, times(1)).findById(1000);
+    }
+
+
+}


### PR DESCRIPTION
# 概要
serviceの単体テストを実装しテストを実行。

# 動作確認
⑴findAllメソッドの呼び出しで存在する映画を全部取得すること
存在するリカーのIDをすべて指定した場合、情報が返ってくることをテストで証明した。
<img width="1920" alt="Screenshot 2023-11-18 at 16 00 28" src="https://github.com/masami-tr/RaiseTech-10/assets/133315049/36027195-28e0-4c80-aca9-f48ac82c45a8">

⑵存在するリカーのIDを指定した時に正常にリカーが返されること
存在するリカーのIDを指定した場合、情報が返ってくることがテストで証明した。
<img width="1920" alt="Screenshot 2023-11-18 at 16 00 52" src="https://github.com/masami-tr/RaiseTech-10/assets/133315049/6149c306-f8c9-4b9c-8572-47f265b4443b">

⑶存在しないリカーのIDを指定した時に例外処理が動作すること
存在しない映画のIDを指定したときに例外処理にスローされることがテストで証明した。
<img width="1920" alt="Screenshot 2023-11-18 at 16 01 08" src="https://github.com/masami-tr/RaiseTech-10/assets/133315049/c0ba59d1-fb55-45f4-8e9d-2e07e382010e">
