### PR TITLE
ServiceのPOST処理単体テストの実装

### DIFF
--- a/src/main/java/com/raisetech10/liquor_management/service/LiquorServiceImpl.java
+++ b/src/main/java/com/raisetech10/liquor_management/service/LiquorServiceImpl.java
@@ -25,7 +25,6 @@ public class LiquorServiceImpl implements LiquorService {
         return liquorMapper.findAll();
     }
 
-    //GET Exception
     @Override
     public Liquor findById(int id) {
         Optional<Liquor> liquor = this.liquorMapper.findById(id);

--- a/src/test/java/com/raisetech10/liquor_management/service/LiquorServiceImplTest.java
+++ b/src/test/java/com/raisetech10/liquor_management/service/LiquorServiceImplTest.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -57,6 +58,16 @@ public class LiquorServiceImplTest {
             liquorServiceImpl.findById(1000);
         });
         verify(liquorMapper, times(1)).findById(1000);
+    }
+
+    //POSTテストコード
+    @Test
+    public void 存在しないリカー情報を新規登録する() {
+        Liquor liquor = new Liquor(10, "ジン", "イギリス", "ビーフィーター", 40);
+        doNothing().when(liquorMapper).insert(liquor);
+        Liquor actual = liquorServiceImpl.createLiquor(liquor);
+        assertThat(actual).isEqualTo(new Liquor(10, "ジン", "イギリス", "ビーフィーター", 40));
+        verify(liquorMapper, times(1)).insert(liquor);
     }
 
 


### PR DESCRIPTION
# 概要
serviceのPOST単体テストを実装しテストを実行。

# 動作確認
⑴存在しないリカー情報を新規登録する
新規リカーの情報を登録した場合、問題なく新規登録処理をできたことをテストで証明した。

<img width="1920" alt="Screenshot 2023-11-18 at 19 15 48" src="https://github.com/masami-tr/RaiseTech-10/assets/133315049/4efaa166-2986-465b-b226-9134b68d36fd">
