### PR TITLE
ServiceのPATCH処理単体テストの実装

### DIFF
--- a/src/test/java/com/raisetech10/liquor_management/service/LiquorServiceImplTest.java
+++ b/src/test/java/com/raisetech10/liquor_management/service/LiquorServiceImplTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -38,6 +39,7 @@ public class LiquorServiceImplTest {
                 new Liquor(3, "ブランデー", "フランス", "ヘネシーXO", 40)
         );
         doReturn(liquor).when(liquorMapper).findAll();
+
         List<Liquor> actual = liquorServiceImpl.findAll();
         assertThat(actual).isEqualTo(liquor);
         verify(liquorMapper, times(1)).findAll();
@@ -45,7 +47,8 @@ public class LiquorServiceImplTest {
 
     @Test
     public void 存在するリカーのIDを指定した時に正常にリカーが返されること() throws ResourceNotFoundException {
-        doReturn(Optional.of(new Liquor(1, "ウイスキー", "スコットランド", "マッカラン", 40))).when(liquorMapper).findById(1);//スタブ内容
+        doReturn(Optional.of(new Liquor(1, "ウイスキー", "スコットランド", "マッカラン", 40)))
+                .when(liquorMapper).findById(1);
 
         Liquor actual = liquorServiceImpl.findById(1);
         assertThat(actual).isEqualTo(new Liquor(1, "ウイスキー", "スコットランド", "マッカラン", 40));
@@ -54,6 +57,7 @@ public class LiquorServiceImplTest {
     @Test
     public void 存在しないリカーのIDを指定した時に例外処理が動作すること() throws ResourceNotFoundException {
         doReturn(Optional.empty()).when(liquorMapper).findById(1000);
+
         assertThrows(ResourceNotFoundException.class, () -> {
             liquorServiceImpl.findById(1000);
         });
@@ -62,12 +66,52 @@ public class LiquorServiceImplTest {
 
     //POSTテストコード
     @Test
-    public void 存在しないリカー情報を新規登録する() {
+    public void 存在しないリカー情報を新規登録すること() {
         Liquor liquor = new Liquor(10, "ジン", "イギリス", "ビーフィーター", 40);
         doNothing().when(liquorMapper).insert(liquor);
+
         Liquor actual = liquorServiceImpl.createLiquor(liquor);
         assertThat(actual).isEqualTo(new Liquor(10, "ジン", "イギリス", "ビーフィーター", 40));
         verify(liquorMapper, times(1)).insert(liquor);
+    }
+
+    //PATCHテストコード
+    @Test
+    public void 存在するリカー情報を更新すること() {
+        Liquor liquor = new Liquor(1, "ウイスキー", "スコットランド", "マッカラン", 40);
+        doReturn(Optional.of(liquor))
+                .when(liquorMapper).findLiquorId(1);
+        doNothing().when(liquorMapper).update(new Liquor(1, "ビール", "日本", "アサヒスーパードライ", 5));
+
+        Liquor actual = liquorServiceImpl.updateLiquor(1, "ビール", "日本", "アサヒスーパードライ", 5);
+        assertThat(actual).isEqualTo(new Liquor(1, "ビール", "日本", "アサヒスーパードライ", 5));
+        verify(liquorMapper, times(1)).findLiquorId(1);
+    }
+
+    @Test
+    public void 存在するリカー情報の特定の属性を更新すること() {
+        Liquor liquor = new Liquor(1, "ウイスキー", "スコットランド", "マッカラン", 40);
+        doReturn(Optional.of(liquor))
+                .when(liquorMapper).findLiquorId(1);
+
+        // ウイスキーの名前をビールに変更して更新
+        Liquor updatedLiquor = new Liquor(1, "ビール", liquor.getProducingCountry(), liquor.getLiquorName(), liquor.getAlcoholContent());
+        doNothing().when(liquorMapper).update(updatedLiquor);
+
+        Liquor actual = liquorServiceImpl.updateLiquor(1, "ビール", null, null, 0);
+        assertThat(actual).isEqualTo(updatedLiquor);
+        verify(liquorMapper, times(1)).findLiquorId(1);
+
+    }
+
+    @Test
+    public void 存在しないリカー情報を更新する時の例外処理が動作すること() throws ResourceNotFoundException {
+        doReturn(Optional.empty()).when(liquorMapper).findLiquorId(1000);
+
+        assertThatThrownBy(
+                () -> liquorServiceImpl.updateLiquor(1000, "ウォッカ", "ロシア", "スピリタス", 90)
+        ).isInstanceOf(ResourceNotFoundException.class);
+        verify(liquorMapper, times(1)).findLiquorId(1000);
     }
 
 


### PR DESCRIPTION
概要
serviceのPATCH単体テストを実装しテストを実行。

動作確認
⑴存在するリカー情報を全部更新すること
存在するリカーの情報を全部更新登録した場合、更新処理をできたことをテストで証明した。
<img width="1920" alt="Screenshot 2023-11-19 at 19 38 43" src="https://github.com/masami-tr/RaiseTech-10/assets/133315049/e3ede94f-a0fa-464d-91ba-ef4cb087dfcb">


⑵存在するリカー情報の特定の属性を更新すること
存在するリカー情報の特定の属性を更新登録した場合、更新処理をできたことをテストで証明した。
<img width="1920" alt="Screenshot 2023-11-19 at 19 39 11" src="https://github.com/masami-tr/RaiseTech-10/assets/133315049/22048a19-37d8-43b3-8ecc-95c737085a1c">


⑶存在しないリカー情報を更新する時の例外処理が動作すること
存在しないリカー情報を更新する時の例外処理が動作することをテストで証明した。
<img width="1920" alt="Screenshot 2023-11-19 at 19 39 25" src="https://github.com/masami-tr/RaiseTech-10/assets/133315049/a727f661-a4ee-4e6e-88b7-550c202e851a">
