### PR TITLE
ServiceのDELETE処理単体テストの実装

### DIFF
--- a/src/test/java/com/raisetech10/liquor_management/service/LiquorServiceImplTest.java
+++ b/src/test/java/com/raisetech10/liquor_management/service/LiquorServiceImplTest.java
@@ -115,18 +115,6 @@ public class LiquorServiceImplTest {
     }
 
     //DELETEテストコード
-    //@Test
-  /*  public void 存在するリカー情報IDを削除すること() {
-        Liquor liquor = new Liquor(1, "ウイスキー", "スコットランド", "マッカラン", 40);
-        doReturn(Optional.of(liquor))
-                .when(liquorMapper).findLiquorId(1);
-        doNothing().when(liquorMapper).delete(1);
-        liquorServiceImpl.deleteLiquor(1);
-        verify(liquorMapper, times(1)).findLiquorId(1);
-        verify(liquorMapper, times(1)).delete(1);
-    }*/
-
-
     @Test
     public void 存在するリカー情報IDを削除すること() {
         Liquor liquor = new Liquor(1, "ウイスキー", "スコットランド", "マッカラン", 40);

--- a/src/test/java/com/raisetech10/liquor_management/service/LiquorServiceImplTest.java
+++ b/src/test/java/com/raisetech10/liquor_management/service/LiquorServiceImplTest.java
@@ -114,5 +114,37 @@ public class LiquorServiceImplTest {
         verify(liquorMapper, times(1)).findLiquorId(1000);
     }
 
+    //DELETEテストコード
+    //@Test
+  /*  public void 存在するリカー情報IDを削除すること() {
+        Liquor liquor = new Liquor(1, "ウイスキー", "スコットランド", "マッカラン", 40);
+        doReturn(Optional.of(liquor))
+                .when(liquorMapper).findLiquorId(1);
+        doNothing().when(liquorMapper).delete(1);
+        liquorServiceImpl.deleteLiquor(1);
+        verify(liquorMapper, times(1)).findLiquorId(1);
+        verify(liquorMapper, times(1)).delete(1);
+    }*/
+
+
+    @Test
+    public void 存在するリカー情報IDを削除すること() {
+        Liquor liquor = new Liquor(1, "ウイスキー", "スコットランド", "マッカラン", 40);
+        doReturn(Optional.of(liquor)).when(liquorMapper).findById(1);
+        doNothing().when(liquorMapper).delete(1);
+        liquorServiceImpl.deleteLiquor(1);
+        verify(liquorMapper, times(1)).findById(1);
+        verify(liquorMapper, times(1)).delete(1);
+    }
+
+    @Test
+    public void 存在しないリカー情報を削除する時の例外処理が動作すること() throws ResourceNotFoundException {
+        doReturn(Optional.empty()).when(liquorMapper).findById(1000);
+        assertThrows(ResourceNotFoundException.class, () -> liquorServiceImpl.deleteLiquor(1000));
+        verify(liquorMapper, times(1)).findById(1000);
+        verify(liquorMapper, times(0)).delete(1000);
+
+    }
+
 
 }


### PR DESCRIPTION
# 概要
serviceのDELETE単体テストを実装しテストを実行。

# 動作確認
⑴存在するリカー情報IDを削除すること
存在するリカー情報IDを削除 、削除処理をできたことをテストで証明した。
<img width="1920" alt="Screenshot 2023-11-19 at 23 55 44" src="https://github.com/masami-tr/RaiseTech-10/assets/133315049/5897325e-4d35-4868-a408-47369215c341">


⑵存在しないリカー情報を削除する時の例外処理が動作すること
存在しないリカー情報を削除する時の例外処理が動作することをテストで証明した。
<img width="1920" alt="Screenshot 2023-11-19 at 23 55 57" src="https://github.com/masami-tr/RaiseTech-10/assets/133315049/006cd445-a277-45e5-af35-8c0846e8574a">
